### PR TITLE
fix endpoint to use ftx us endpoint

### DIFF
--- a/clients.py
+++ b/clients.py
@@ -5,15 +5,14 @@ from websockets.client import FtxWebsocketClient
 
 api_key = 'API_KEY'
 secret = 'API_SECRET'
+subaccount_name = 'YOUR_SUBACCOUNT_NAME'
 
 def main():
-    rest_client = FtxClient(api_key, secret)
-    websocket_client = FtxWebsocketClient(api_key, secret)
-    websocket_client.connect()
-    while(True):
-        time.sleep(2)
-        print(websocket_client.get_orderbook('BTC/USD'))
-        print(rest_client.get_orderbook('BTC/USD', depth=1))
+    rest_client = FtxClient(api_key, secret, subaccount_name)
+    
+    # a request that actually requires proper login credentials to get
+    print(rest_client.get_account_info())
+
 
 if __name__ == '__main__':
     main()

--- a/rest/client.py
+++ b/rest/client.py
@@ -9,7 +9,7 @@ from ciso8601 import parse_datetime
 
 
 class FtxClient:
-    _ENDPOINT = 'https://ftx.com/api/'
+    _ENDPOINT = 'https://ftx.us/api/'
 
     def __init__(self, api_key=None, api_secret=None, subaccount_name=None) -> None:
         self._session = Session()
@@ -39,11 +39,11 @@ class FtxClient:
         if prepared.body:
             signature_payload += prepared.body
         signature = hmac.new(self._api_secret.encode(), signature_payload, 'sha256').hexdigest()
-        request.headers['FTX-KEY'] = self._api_key
-        request.headers['FTX-SIGN'] = signature
-        request.headers['FTX-TS'] = str(ts)
+        request.headers['FTXUS-KEY'] = self._api_key
+        request.headers['FTXUS-SIGN'] = signature
+        request.headers['FTXUS-TS'] = str(ts)
         if self._subaccount_name:
-            request.headers['FTX-SUBACCOUNT'] = urllib.parse.quote(self._subaccount_name)
+            request.headers['FTXUS-SUBACCOUNT'] = urllib.parse.quote(self._subaccount_name)
 
     def _process_response(self, response: Response) -> Any:
         try:


### PR DESCRIPTION
The provided example uses the ftx.com endpoints, which doesn't work for any of the teams in our club. This pull request should ensure that all teams can actually use their API keys and access all the API features and endpoints.